### PR TITLE
remove 'DeleteCases' from cleanup as now done prior

### DIFF
--- a/Blaise.Cati.Tests.Behaviour/Steps/AccessCaseSteps.cs
+++ b/Blaise.Cati.Tests.Behaviour/Steps/AccessCaseSteps.cs
@@ -107,7 +107,6 @@ namespace Blaise.Cati.Tests.Behaviour.Steps
         public static void CleanUpFeature()
         {
             CatiInterviewHelper.GetInstance().DeleteInterviewUser();
-            CaseHelper.GetInstance().DeleteCases();
             InstrumentHelper.GetInstance().UninstallSurvey();
         }
 


### PR DESCRIPTION
Small PR just to remove the DeleteCases method being called during the cleanup after running tests. This is now done prior to running tests. 